### PR TITLE
Add working on windows server case in file_uri_to_path function

### DIFF
--- a/py_src/jupyter_lsp/paths.py
+++ b/py_src/jupyter_lsp/paths.py
@@ -28,7 +28,12 @@ def file_uri_to_path(file_uri):
     windows_path = os.name == "nt"
     file_uri_parsed = urlparse(file_uri)
     file_uri_path_unquoted = unquote(file_uri_parsed.path)
-    if windows_path and file_uri_path_unquoted.startswith("/"):
+    # when windows, and file is on a server
+    if windows_path and file_uri_parsed.netloc:
+        file_path = file_uri.split(":")[1]
+        result = unquote(file_path)
+    # when windows, and file is local
+    elif windows_path and file_uri_path_unquoted.startswith("/"):
         result = file_uri_path_unquoted[1:]  # pragma: no cover
     else:
         result = file_uri_path_unquoted  # pragma: no cover


### PR DESCRIPTION
<!--
Thanks for contributing to jupyterlab-lsp!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Fixes  #419
<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

For a file on a windows server the uri looks like "file://server/share/path/to/file" which was not properly parsed by file_uri_to_path.
The urlparse function gives netloc=server, path=/share/path/to/file
When taking the path part, the server is omitted and the proper path is lost.

In the case where the project is on windows and the netloc part is not empty, this modification takes the part after "file:" in the file uri, and unquoted it. This gives file proper path, 
even though inelegantly...

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to public APIs. -->

## Chores

- [ ] linted
- [ ] tested
- [ ] documented
- [ ] changelog entry
